### PR TITLE
Update pre-commit

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,11 +1,16 @@
 exclude_paths:
-  - .
   - temp
+  - .github
+  - .pre-commit-config.yaml
 parseable: true
 quiet: true
 skip_list:
-  - 301
-  - 305
-  - 306
+  - "no-changed-when"
+  - "package-latest"
+  - "name[play]"
+  - "name[casing]"
+  - "fqcn[action]"
+  - "fqcn[action-core]"
+  - "yaml[line-length]"
 use_default_rules: true
 verbosity: 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
+ci:
+    skip: [ansible-lint]
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.6.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
@@ -9,7 +12,8 @@ repos:
     -   id: pretty-format-json
         args: [--autofix]
 -   repo: https://github.com/ansible/ansible-lint
-    rev: v4.2.0
+    rev: v24.9.2
     hooks:
     -   id: ansible-lint
-        files: packer/.*\.(yaml|yml)$
+        additional_dependencies:
+          - ansible


### PR DESCRIPTION
* update pre-commit linters
* Fix or ignore new linter errors
* playbook contains "community.general.sudoers" which requires installing `additional_dependencies`.  That however does not work with pre-commit SAS service therefore we have to disable that linter in the SAS service and run it with github actions.

